### PR TITLE
Add support for Organization-level Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ github-runner-monitor/
 
    aws ssm put-parameter --name "/github-runner-monitor/repositories" \
      --type String --value '["owner/repo1", "owner/repo2"]'
-   
+
+   aws ssm put-parameter --name "/github-runner-monitor/organizations" \
+     --type String --value '["owner"]'
+
    aws ssm put-parameter --name "/github-runner-monitor/slack-webhook" \
      --type SecureString --value "https://hooks.slack.com/services/your/webhook/url"
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,26 @@ You can test the Lambda function locally using AWS SAM CLI, which allows you to 
    EOL
    ```
 
-2. Create SAM template for local testing
+2. Create a SAM-specific environment variable override file
+  ```bash
+  cat > .env.json << EOL
+  {
+    "Parameters": {
+      "STATELYDB_SCHEMA_ID": 1234,
+      "STATELYDB_STORE_ID": 1234,
+      "STATELYDB_ACCESS_KEY": "secret-here",
+      "STATELYDB_REGION": "us-east-1",
+      "REPOS": "[\"StatelyCloud/stately\"]",
+      "ORGANIZATIONS": "[\"StatelyCloud\"]",
+      "GITHUB_TOKEN": "secret-here",
+      "AWS_REGION": "us-west-2",
+      "SLACK_WEBHOOK": "secret-here"
+    }
+  }
+  EOL
+  ```
+
+3. Create SAM template for local testing
    ```bash
    cat > template.yaml << EOL
    AWSTemplateFormatVersion: '2010-09-09'
@@ -264,7 +283,7 @@ You can test the Lambda function locally using AWS SAM CLI, which allows you to 
    EOL
    ```
 
-3. Invoke the Lambda function locally
+4. Invoke the Lambda function locally
    ```bash
    # Ensure AWS_PROFILE is set if you're using named profiles
    export AWS_PROFILE=your-profile-name
@@ -275,7 +294,7 @@ You can test the Lambda function locally using AWS SAM CLI, which allows you to 
      --region $(grep AWS_REGION .env.dev | cut -d= -f2)
    ```
 
-4. Debug the Lambda function with VS Code
+5. Debug the Lambda function with VS Code
    - Create a `.vscode/launch.json` file:
    ```json
    {

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -19,6 +19,7 @@ const SSM_STATELYDB_STORE_ID = "/github-runner-monitor/statelydb-store-id";
 const SSM_STATELYDB_REGION = "/github-runner-monitor/statelydb-region";
 const SSM_REPOSITORIES = "/github-runner-monitor/repositories";
 const SSM_SLACK_WEBHOOK = "/github-runner-monitor/slack-webhook";
+const SSM_ORGANIZATIONS = "/github-runner-monitor/organizations";
 
 // Initialize the SSM client
 const ssm = new SSMClient();
@@ -282,6 +283,7 @@ async function fetchSSMParameters() {
         SSM_STATELYDB_REGION,
         SSM_REPOSITORIES,
         SSM_SLACK_WEBHOOK,
+        SSM_ORGANIZATIONS,
       ],
       WithDecryption: true,
     }),
@@ -302,6 +304,7 @@ async function fetchSSMParameters() {
     statelydbRegion: getParameter(SSM_STATELYDB_REGION),
     repositories: getParameter(SSM_REPOSITORIES),
     slackWebhook: getParameter(SSM_SLACK_WEBHOOK),
+    organizations: getParameter(SSM_ORGANIZATIONS),
   };
 }
 

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -55,6 +55,7 @@ export const handler = async (_event: Record<string, unknown>) => {
       statelydbStoreId: params.statelydbStoreId,
       statelydbRegion: params.statelydbRegion,
       repositories: params.repositories,
+      organizations: params.organizations,
     });
 
     // Initialize StatelyDB client
@@ -100,9 +101,18 @@ export const handler = async (_event: Record<string, unknown>) => {
           await statelyClient.put(repository);
         }
 
-        // Fetch runners from GitHub API
-        const runners = await fetchGitHubRunners(repo, params.githubToken);
+        // Fetch runners from GitHub API for Repositories
+        const runners = await fetchGitHubRunnersForRepository(repo, params.githubToken);
         console.log(`Found ${runners.length} runners for repository ${repoId}`);
+
+        // Fetch runners from GitHub API for Organizations
+        const organizations = JSON.parse(params.organizations);
+        for (const org of organizations) {
+          const orgRunners = await fetchGitHubRunnersForOrganization(org, params.githubToken);
+          console.log(`Found ${orgRunners.length} runners for organization ${org}`);
+          runners.push(...orgRunners);
+        }
+        console.log(`Total runners after merging: ${runners.length}`);
 
         // Get existing runners from StatelyDB
         const existingRunners = await fetchExistingRunners(
@@ -261,9 +271,10 @@ export const handler = async (_event: Record<string, unknown>) => {
 /**
  * Fetch all SSM parameters needed for the function
  */
-async function fetchSSMParameters() {
+async function fetchSSMParameters() { 
+
   if (process.env.AWS_SAM_LOCAL) {
-    // Return mock parameters for local testing
+    console.log("Running in local mode, using environment variables");
     return {
       githubToken: process.env.GITHUB_TOKEN,
       statelydbAccessKey: process.env.STATELYDB_ACCESS_KEY,
@@ -271,6 +282,7 @@ async function fetchSSMParameters() {
       statelydbRegion: process.env.STATELYDB_REGION,
       repositories: process.env.REPOS,
       slackWebhook: process.env.SLACK_WEBHOOK,
+      organizations: process.env.ORGANIZATIONS,
     };
   }
 
@@ -309,26 +321,67 @@ async function fetchSSMParameters() {
 }
 
 /**
- * Fetch runners for a repository from GitHub API
+ * Fetch runners for a Github Repository
+ * @param repo - The repository in the format "owner/repo"
+ * @param githubToken - The GitHub token for authentication
+ * @returns A promise that resolves to an array of GitHub runners
  */
-async function fetchGitHubRunners(
+async function fetchGitHubRunnersForRepository(
   repo: string,
   githubToken: string,
 ): Promise<GitHubRunner[]> {
   try {
-    const response = await axios.get(
+    return await fetchGitHubRunnersFromEndpoint(
       `https://api.github.com/repos/${repo}/actions/runners`,
-      {
-        headers: {
-          Authorization: `token ${githubToken}`,
-          Accept: "application/vnd.github.v3+json",
-        },
-      },
+      githubToken,
     );
-
-    return response.data.runners;
   } catch (error) {
     console.error(`Error fetching runners for repository ${repo}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch runners for a GitHub Organization
+ * @param org - The organization name
+ * @param githubToken - The GitHub token for authentication
+ * @returns A promise that resolves to an array of GitHub runners
+ */
+async function fetchGitHubRunnersForOrganization(
+  org: string,
+  githubToken: string,
+): Promise<GitHubRunner[]> {
+  try {
+    return await fetchGitHubRunnersFromEndpoint(
+      `https://api.github.com/orgs/${org}/actions/runners`,
+      githubToken,
+    );
+  } catch (error) {
+    console.error(`Error fetching runners for organization ${org}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch runners for a given GitHub API endpoint
+ * @param endpoint - The GitHub API endpoint
+ * @param githubToken - The GitHub token for authentication
+ * @returns A promise that resolves to an array of GitHub runners
+ */
+async function fetchGitHubRunnersFromEndpoint(
+  endpoint: string,
+  githubToken: string,
+): Promise<GitHubRunner[]> {
+  try {
+    const response = await axios.get(endpoint, {
+      headers: {
+        Authorization: `token ${githubToken}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    });
+    return response.data.runners;
+  } catch (error) {
+    console.error(`Error fetching runners from ${endpoint}:`, error);
     throw error;
   }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -1,9 +1,21 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
+
 Resources:
   GitHubRunnerMonitorFunction:
     Type: AWS::Serverless::Function
     Properties:
+      Environment:
+        Variables:
+          STATELYDB_SCHEMA_ID:
+          STATELYDB_STORE_ID:
+          STATELYDB_ACCESS_KEY:
+          STATELYDB_REGION:
+          REPOS:
+          ORGANIZATIONS:
+          GITHUB_TOKEN:
+          AWS_REGION:
+          SLACK_WEBHOOK":
       CodeUri: ./dist/
       Handler: probe.handler
       Runtime: nodejs18.x

--- a/template.yaml
+++ b/template.yaml
@@ -15,7 +15,7 @@ Resources:
           ORGANIZATIONS:
           GITHUB_TOKEN:
           AWS_REGION:
-          SLACK_WEBHOOK":
+          SLACK_WEBHOOK:
       CodeUri: ./dist/
       Handler: probe.handler
       Runtime: nodejs18.x


### PR DESCRIPTION
This change adds support for Runners that are configured at the Organization level, whereas previously we supported Repository-level Runners.

**Changes**
* Added support for Organization-level Runners to the probe
* Updated local SAM testing template with envrionment variables to support testing with overrides for local SAM invocation
* Updated README with new SSM parameter configuration and environment variable configuration

**Testing**
* Tested locally with SAM invoke
* Deployed to Stately production environment